### PR TITLE
docs: added k8s-bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Other open source projects that use Argo:
 * [Couler](https://github.com/couler-proj/couler) provides a unified interface for constructing and managing workflows on different workflow engines.
 * [Devtron](https://github.com/devtron-labs/devtron) is a Web-Based CI/CD Platform for Kubernetes, powered by Argo.
 * [Flowify](https://equinor.github.io/flowify-documentation/) Collaborative no code UI for Argo Workflows.
+* [k8s-bootstrapper](https://github.com/hivenetes/k8s-bootstrapper) is a framework to set up production ready Kubernetes clusters using Terraform and Argo CD.
 * [Kedro](https://github.com/quantumblacklabs/kedro) is an open-source Python framework for creating reproducible, maintainable and modular data science code.
 * [Kubeflow Katib](https://github.com/kubeflow/katib) is a Kubernetes-native project for automated machine learning (AutoML).
 * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines) is dedicated to making deployments of machine learning workflows on Kubernetes simple, portable, and scalable with Kubeflow.


### PR DESCRIPTION
- The [k8s-bootstrapper](https://github.com/hivenetes/k8s-bootstrapper) project is a customizable and extendable framework to set up production-grade k8s clusters.
- It is built around Terraform and Argo CD. 
- This project integrates popular battle-tested open-source software and solutions that provide a production-grade out-of-box Kubernetes experience.