### PR TITLE
feat: add KubeStellar Console to Ecosystem Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Other open source projects that use Argo:
 * [kubefirst](https://github.com/kubefirst/kubefirst/) provides fully automated open source application delivery and infrastructure management GitOps platforms for Kubernetes.
 * [Kubeflow Katib](https://github.com/kubeflow/katib) is a Kubernetes-native project for automated machine learning (AutoML).
 * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines) is dedicated to making deployments of machine learning workflows on Kubernetes simple, portable, and scalable with Kubeflow.
+* [KubeStellar Console](https://github.com/kubestellar/console) is an AI-powered multi-cluster Kubernetes dashboard with built-in Argo CD integration for real-time observability and AI-guided operations across hybrid and edge clusters. CNCF Sandbox project.
 * [Meshery](https://github.com/meshery/meshery) is the open source, cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud). 
 * [Metaflow](https://github.com/Netflix/metaflow) is a Python library for building and managing real-life data science projects.
 * [Nixidy](https://github.com/arnarg/nixidy) is a tool to apply the rendered manifest pattern using NixOS-like modules to define Argo CD applications.


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Ecosystem Projects** section under "Other open source projects that use Argo".

**Why it belongs here:**
- Open source AI-powered multi-cluster Kubernetes dashboard with first-class Argo CD integration
- Surfaces Argo CD application health, sync status, and GitOps pipelines across multiple clusters
- Also integrates Argo Workflows and Argo Rollouts visibility
- Real-time observability across hybrid edge and cloud environments
- CNCF Sandbox project (Apache 2.0)

**Links:**
- Website: https://console.kubestellar.io
- GitHub: https://github.com/kubestellar/console