### PR TITLE
feat: add KubeStellar Console to projects that use Argo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Other open source projects that use Argo:
 * [Kedro](https://github.com/quantumblacklabs/kedro) is an open-source Python framework for creating reproducible, maintainable and modular data science code.
 * [kubechecks](https://github.com/zapier/kubechecks) is a tool to check what changes a pull-request will make to your ArgoCD applications, with reporting directly in the PR.
 * [kubefirst](https://github.com/kubefirst/kubefirst/) provides fully automated open source application delivery and infrastructure management GitOps platforms for Kubernetes.
+* [KubeStellar Console](https://github.com/kubestellar/console) is a multi-cluster Kubernetes dashboard with built-in Argo CD integration for visualizing application deployments, sync status, and rollout health across clusters.
 * [Kubeflow Katib](https://github.com/kubeflow/katib) is a Kubernetes-native project for automated machine learning (AutoML).
 * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines) is dedicated to making deployments of machine learning workflows on Kubernetes simple, portable, and scalable with Kubeflow.
 * [Meshery](https://github.com/meshery/meshery) is the open source, cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud). 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Other open source projects that use Argo:
 * [Kedro](https://github.com/quantumblacklabs/kedro) is an open-source Python framework for creating reproducible, maintainable and modular data science code.
 * [kubechecks](https://github.com/zapier/kubechecks) is a tool to check what changes a pull-request will make to your ArgoCD applications, with reporting directly in the PR.
 * [kubefirst](https://github.com/kubefirst/kubefirst/) provides fully automated open source application delivery and infrastructure management GitOps platforms for Kubernetes.
-* [KubeStellar Console](https://github.com/kubestellar/console) is a multi-cluster Kubernetes dashboard with built-in Argo CD integration for visualizing application deployments, sync status, and rollout health across clusters.
 * [Kubeflow Katib](https://github.com/kubeflow/katib) is a Kubernetes-native project for automated machine learning (AutoML).
 * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines) is dedicated to making deployments of machine learning workflows on Kubernetes simple, portable, and scalable with Kubeflow.
+* [KubeStellar Console](https://github.com/kubestellar/console) is an AI-powered multi-cluster Kubernetes management dashboard (CNCF Sandbox) that integrates with Argo CD for GitOps-driven workload placement and monitoring across edge and cloud clusters.
 * [Meshery](https://github.com/meshery/meshery) is the open source, cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud). 
 * [Metaflow](https://github.com/Netflix/metaflow) is a Python library for building and managing real-life data science projects.
 * [Nixidy](https://github.com/arnarg/nixidy) is a tool to apply the rendered manifest pattern using NixOS-like modules to define Argo CD applications.


### PR DESCRIPTION
## Summary

Add [KubeStellar Console](https://github.com/kubestellar/console) to the "Other open source projects that use Argo" section.

**KubeStellar Console** is a CNCF Sandbox project — an AI-powered multi-cluster Kubernetes management dashboard that integrates with Argo CD for GitOps-driven workload placement across edge and cloud clusters.

### Argo integration
- **Argo CD**: Dashboard cards show Argo CD application health, sync status, and deployment history across multiple clusters
- **Argo Workflows**: Pipeline monitoring cards for Argo Workflow execution
- Used in multi-cluster scenarios to orchestrate GitOps-driven deployments via Argo CD

### Resources
- GitHub: https://github.com/kubestellar/console
- CNCF Sandbox: https://www.cncf.io/projects/kubestellar/